### PR TITLE
Refining types for waiter-manager

### DIFF
--- a/addon/noop-test-waiter.ts
+++ b/addon/noop-test-waiter.ts
@@ -1,4 +1,4 @@
-import { ITestWaiter, Token } from './types';
+import { ITestWaiter, Token, ITestWaiterDebugInfo } from './types';
 
 /**
  * A class providing a production, noop replacement for the {TestWaiter<T>} class.
@@ -21,7 +21,7 @@ export default class NoopTestWaiter implements ITestWaiter {
   waitUntil(): boolean {
     return true;
   }
-  debugInfo(): unknown {
-    return undefined;
+  debugInfo(): ITestWaiterDebugInfo[] {
+    return [];
   }
 }

--- a/addon/types/index.ts
+++ b/addon/types/index.ts
@@ -4,7 +4,7 @@ export type Token = unknown;
 export interface IWaiter {
   name: WaiterName;
   waitUntil(): boolean;
-  debugInfo(): unknown;
+  debugInfo(): ITestWaiterDebugInfo[];
 }
 
 export interface ITestWaiter<T = Token> extends IWaiter {
@@ -20,6 +20,6 @@ export interface ITestWaiterDebugInfo {
 export interface IPendingWaiterState {
   pending: number;
   waiters: {
-    [waiterName: string]: true | unknown[];
+    [waiterName: string]: ITestWaiterDebugInfo[] | true;
   };
 }

--- a/addon/waiter-manager.ts
+++ b/addon/waiter-manager.ts
@@ -1,6 +1,6 @@
-import { IWaiter, IPendingWaiterState } from './types';
+import { WaiterName, IWaiter, IPendingWaiterState } from './types';
 
-const WAITERS = new Map();
+const WAITERS: Map<WaiterName, IWaiter> = new Map<WaiterName, IWaiter>();
 
 /**
  * Registers a waiter.


### PR DESCRIPTION
The types in `waiter-manager.ts` were a little loose. This PR tightens them up a bit.