### PR TITLE
Add public API for clearing waiter items

### DIFF
--- a/addon/noop-test-waiter.ts
+++ b/addon/noop-test-waiter.ts
@@ -21,7 +21,10 @@ export default class NoopTestWaiter implements ITestWaiter {
   waitUntil(): boolean {
     return true;
   }
+
   debugInfo(): ITestWaiterDebugInfo[] {
     return [];
   }
+
+  reset(): void {}
 }

--- a/addon/test-waiter.ts
+++ b/addon/test-waiter.ts
@@ -117,4 +117,14 @@ export default class TestWaiter<T = Token> implements ITestWaiter<T> {
   debugInfo(): ITestWaiterDebugInfo[] {
     return [...this.items.values()];
   }
+
+  /**
+   * Resets the waiter state, clearing items tracking async operations in this waiter.
+   *
+   * @public
+   * @method reset
+   */
+  reset(): void {
+    this.items.clear();
+  }
 }

--- a/addon/types/index.ts
+++ b/addon/types/index.ts
@@ -10,6 +10,7 @@ export interface IWaiter {
 export interface ITestWaiter<T = Token> extends IWaiter {
   beginAsync(token?: T, label?: string): T;
   endAsync(token: T): void;
+  reset(): void;
 }
 
 export interface ITestWaiterDebugInfo {

--- a/tests/unit/test-waiter-test.ts
+++ b/tests/unit/test-waiter-test.ts
@@ -247,4 +247,16 @@ module('test-waiter', function(hooks) {
       'All thenables are run',
     ]);
   });
+
+  test('waiter can clear items', function(assert) {
+    let waiter = new TestWaiter('my-waiter');
+
+    waiter.beginAsync();
+
+    assert.equal(waiter.items.size, 1);
+
+    waiter.reset();
+
+    assert.equal(waiter.items.size, 0);
+  });
 });


### PR DESCRIPTION
There are certain instances where we want to force reset all waiter items in order to ensure that waiters are not incorrectly blocking settledness in tests. This PR adds the `reset` method to the `TestWaiter` class to allow for resetting.