### PR TITLE
Refining when CI Build runs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,13 @@
 name: CI Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'v*'
+  pull_request: {}
+  schedule:
+    - cron: '0 3 * * *' # daily, at 3am
 
 jobs:
   test:


### PR DESCRIPTION
As indicated in the description, this PR refines when the CI Build action runs. 

Borrowed from https://github.com/ember-template-lint/ember-template-lint/blob/7658c3399c5fab17eac1fabdd9d3e24be208be84/.github/workflows/ci.yml#L4-L10