### PR TITLE
Dropping support for node 8

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 8.x
+          node-version: 10.x
       - name: install dependencies
         run: yarn install
       - name: lint

--- a/package.json
+++ b/package.json
@@ -70,11 +70,8 @@
     "release-it-lerna-changelog": "^1.0.3",
     "typescript": "^3.7.4"
   },
-  "resolutions": {
-    "**/engine.io": "~3.3.0"
-  },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
This PR also removes the redundant .travis.yml.