### PR TITLE
Fixes default tokens to be truthy

### DIFF
--- a/addon/test-waiter.ts
+++ b/addon/test-waiter.ts
@@ -1,7 +1,8 @@
-import { ITestWaiter, WaiterName, ITestWaiterDebugInfo, Token } from './types';
+import { ITestWaiter, ITestWaiterDebugInfo, Token, WaiterName } from './types';
+
 import { register } from './waiter-manager';
 
-let token: number = 0;
+let token: number = 1;
 
 function getNextToken(): number {
   return token++;

--- a/tests/unit/test-waiter-test.ts
+++ b/tests/unit/test-waiter-test.ts
@@ -24,6 +24,14 @@ module('test-waiter', function(hooks) {
     assert.ok(typeof token === 'number', 'A token was returned from beginAsync');
   });
 
+  test('test waiters return a truthy token from beginAsync when no token provided', function(assert) {
+    let waiter = new TestWaiter('my-waiter');
+
+    let token = waiter.beginAsync();
+
+    assert.ok(token, 'A token was returned from beginAsync and is truthy');
+  });
+
   test('test waiters automatically register when beginAsync is invoked when no token provied', function(assert) {
     let waiter = new TestWaiter('my-waiter');
 


### PR DESCRIPTION
Currently in the `test-waiter` module, we use a zero-based counter for the default tokens. This presents a problem for consumers when checking for the existence of a valid token:

```js
let token = waiter.beginAsync();

// ...

if (token) {
  waiter.endAsync(token);
}
```

This PR changes tokens to be one-based, so that the truthy evaluation will always pass, and consumers won't have to know that the first token is magically different than the rest.